### PR TITLE
Add root-keys command

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,11 @@ Recreates the `targets` manifest based on the files in `repository/targets`.
 
 Removes all staged manifests and targets.
 
+#### `tuf root-keys`
+
+Outputs a JSON serialized array of root keys to STDOUT. The resulting JSON
+should be distributed to clients for performing initial updates.
+
 For a list of supported commands, run `tuf help` from the command line.
 
 ### Examples

--- a/repo.go
+++ b/repo.go
@@ -176,6 +176,26 @@ func (r *Repo) GenKey(keyRole string) error {
 	return r.setMeta("root.json", root)
 }
 
+func (r *Repo) RootKeys() ([]*data.Key, error) {
+	root, err := r.root()
+	if err != nil {
+		return nil, err
+	}
+	role, ok := root.Roles["root"]
+	if !ok {
+		return nil, nil
+	}
+	rootKeys := make([]*data.Key, len(role.KeyIDs))
+	for i, id := range role.KeyIDs {
+		key, ok := root.Keys[id]
+		if !ok {
+			return nil, fmt.Errorf("tuf: invalid root metadata")
+		}
+		rootKeys[i] = key
+	}
+	return rootKeys, nil
+}
+
 func (r *Repo) setMeta(name string, meta interface{}) error {
 	keys, err := r.local.GetKeys(strings.TrimSuffix(name, ".json"))
 	if err != nil {

--- a/tuf/main.go
+++ b/tuf/main.go
@@ -31,6 +31,7 @@ Commands:
   commit       Commit staged files to the repository
   regenerate   Recreate the targets manifest
   clean        Remove all staged manifests
+  root-keys    Output a JSON serialized array of root keys to STDOUT
 
 See "tuf help <command>" for more information on a specific command
 `

--- a/tuf/root_keys.go
+++ b/tuf/root_keys.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+
+	"github.com/flynn/go-docopt"
+	"github.com/flynn/go-tuf"
+)
+
+func init() {
+	register("root-keys", cmdRootKeys, `
+usage: tuf root-keys
+
+Outputs a JSON serialized array of root keys to STDOUT.
+
+The resulting JSON should be distributed to clients for performing initial updates.
+`)
+}
+
+func cmdRootKeys(args *docopt.Args, repo *tuf.Repo) error {
+	keys, err := repo.RootKeys()
+	if err != nil {
+		return err
+	}
+	return json.NewEncoder(os.Stdout).Encode(keys)
+}


### PR DESCRIPTION
The client will need the root keys when performing the initial update, so this change helps the maintainer distribute those keys.