### PR TITLE
Support setting manifest expires via the CLI

### DIFF
--- a/data/types.go
+++ b/data/types.go
@@ -42,6 +42,21 @@ type KeyValue struct {
 	Private HexBytes `json:"private,omitempty"`
 }
 
+func DefaultExpires(role string) time.Time {
+	switch role {
+	case "root":
+		return time.Now().AddDate(1, 0, 0).UTC()
+	case "targets":
+		return time.Now().AddDate(0, 3, 0).UTC()
+	case "snapshot":
+		return time.Now().AddDate(0, 0, 7).UTC()
+	case "timestamp":
+		return time.Now().AddDate(0, 0, 1).UTC()
+	default:
+		return time.Time{}
+	}
+}
+
 type Root struct {
 	Type    string           `json:"_type"`
 	Version int              `json:"version"`
@@ -56,7 +71,7 @@ func NewRoot() *Root {
 	return &Root{
 		Type:    "root",
 		Version: 1,
-		Expires: time.Now().AddDate(1, 0, 0).UTC(),
+		Expires: DefaultExpires("root"),
 		Keys:    make(map[string]*Key),
 		Roles:   make(map[string]*Role),
 	}
@@ -80,7 +95,7 @@ func NewSnapshot() *Snapshot {
 	return &Snapshot{
 		Type:    "snapshot",
 		Version: 1,
-		Expires: time.Now().AddDate(0, 0, 7).UTC(),
+		Expires: DefaultExpires("snapshot"),
 		Meta:    make(Files),
 	}
 }
@@ -102,7 +117,7 @@ func NewTargets() *Targets {
 	return &Targets{
 		Type:    "targets",
 		Version: 1,
-		Expires: time.Now().AddDate(0, 3, 0).UTC(),
+		Expires: DefaultExpires("targets"),
 		Targets: make(Files),
 	}
 }
@@ -118,7 +133,7 @@ func NewTimestamp() *Timestamp {
 	return &Timestamp{
 		Type:    "timestamp",
 		Version: 1,
-		Expires: time.Now().AddDate(0, 0, 1).UTC(),
+		Expires: DefaultExpires("timestamp"),
 		Meta:    make(Files),
 	}
 }

--- a/errors.go
+++ b/errors.go
@@ -1,6 +1,9 @@
 package tuf
 
-import "fmt"
+import (
+	"fmt"
+	"time"
+)
 
 type ErrMissingMetadata struct {
 	Name string
@@ -41,4 +44,12 @@ type ErrInvalidRole struct {
 
 func (e ErrInvalidRole) Error() string {
 	return fmt.Sprintf("tuf: invalid role %s", e.Role)
+}
+
+type ErrInvalidExpires struct {
+	Expires time.Time
+}
+
+func (e ErrInvalidExpires) Error() string {
+	return fmt.Sprintf("tuf: invalid expires: %s", e.Expires)
 }

--- a/tuf/add.go
+++ b/tuf/add.go
@@ -7,12 +7,22 @@ import (
 
 func init() {
 	register("add", cmdAdd, `
-usage: tuf add <path>
+usage: tuf add [--expires=<days>] <path>
 
 Add a target file.
+
+Options:
+  --expires=<days>   Set the targets manifest to expire <days> days from now.
 `)
 }
 
 func cmdAdd(args *docopt.Args, repo *tuf.Repo) error {
+	if arg := args.String["--expires"]; arg != "" {
+		expires, err := parseExpires(arg)
+		if err != nil {
+			return err
+		}
+		return repo.AddTargetWithExpires(args.String["<path>"], nil, expires)
+	}
 	return repo.AddTarget(args.String["<path>"], nil)
 }

--- a/tuf/gen_key.go
+++ b/tuf/gen_key.go
@@ -7,16 +7,26 @@ import (
 
 func init() {
 	register("gen-key", cmdGenKey, `
-usage: tuf gen-key <role>
+usage: tuf gen-key [--expires=<days>] <role>
 
 Generate a new signing key for the given role.
 
 The key will be serialized to JSON and written to the "keys" directory with
 filename pattern "ROLE-KEYID.json". The root manifest will also be staged
 with the addition of the key's ID to the role's list of key IDs.
+
+Options:
+  --expires=<days>   Set the root manifest to expire <days> days from now.
 `)
 }
 
 func cmdGenKey(args *docopt.Args, repo *tuf.Repo) error {
+	if arg := args.String["--expires"]; arg != "" {
+		expires, err := parseExpires(arg)
+		if err != nil {
+			return err
+		}
+		return repo.GenKeyWithExpires(args.String["<role>"], expires)
+	}
 	return repo.GenKey(args.String["<role>"])
 }

--- a/tuf/main.go
+++ b/tuf/main.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strconv"
+	"time"
 
 	"github.com/flynn/go-docopt"
 	"github.com/flynn/go-tuf"
@@ -96,4 +98,12 @@ func runCommand(name string, args []string) error {
 		return err
 	}
 	return cmd.f(parsedArgs, repo)
+}
+
+func parseExpires(arg string) (time.Time, error) {
+	days, err := strconv.Atoi(arg)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("failed to parse --expires arg: %s", err)
+	}
+	return time.Now().AddDate(0, 0, days).UTC(), nil
 }

--- a/tuf/remove.go
+++ b/tuf/remove.go
@@ -7,12 +7,22 @@ import (
 
 func init() {
 	register("remove", cmdRemove, `
-usage: tuf remove <path>
+usage: tuf remove [--expires=<days>] <path>
 
 Remove a target file.
+
+Options:
+  --expires=<days>   Set the targets manifest to expire <days> days from now.
 `)
 }
 
 func cmdRemove(args *docopt.Args, repo *tuf.Repo) error {
+	if arg := args.String["--expires"]; arg != "" {
+		expires, err := parseExpires(arg)
+		if err != nil {
+			return err
+		}
+		return repo.RemoveTargetWithExpires(args.String["<path>"], expires)
+	}
 	return repo.RemoveTarget(args.String["<path>"])
 }

--- a/tuf/snapshot.go
+++ b/tuf/snapshot.go
@@ -7,13 +7,23 @@ import (
 
 func init() {
 	register("snapshot", cmdSnapshot, `
-usage: tuf snapshot [--compression=<format>]
+usage: tuf snapshot [--expires=<days>] [--compression=<format>]
 
 Update the snapshot manifest.
+
+Options:
+  --expires=<days>   Set the snapshot manifest to expire <days> days from now.
 `)
 }
 
 func cmdSnapshot(args *docopt.Args, repo *tuf.Repo) error {
 	// TODO: parse --compression
+	if arg := args.String["--expires"]; arg != "" {
+		expires, err := parseExpires(arg)
+		if err != nil {
+			return err
+		}
+		return repo.SnapshotWithExpires(tuf.CompressionTypeNone, expires)
+	}
 	return repo.Snapshot(tuf.CompressionTypeNone)
 }

--- a/tuf/timestamp.go
+++ b/tuf/timestamp.go
@@ -7,12 +7,22 @@ import (
 
 func init() {
 	register("timestamp", cmdTimestamp, `
-usage: tuf timestamp
+usage: tuf timestamp [--expires=<days>]
 
 Update the timestamp manifest.
+
+Options:
+  --expires=<days>   Set the timestamp manifest to expire <days> days from now.
 `)
 }
 
 func cmdTimestamp(args *docopt.Args, repo *tuf.Repo) error {
+	if arg := args.String["--expires"]; arg != "" {
+		expires, err := parseExpires(arg)
+		if err != nil {
+			return err
+		}
+		return repo.TimestampWithExpires(expires)
+	}
 	return repo.Timestamp()
 }


### PR DESCRIPTION
This will help testing indefinite freeze attacks in the client.

Closes #9.