### PR TITLE
Bump metadata versions on change

### DIFF
--- a/data/types.go
+++ b/data/types.go
@@ -70,7 +70,6 @@ type Root struct {
 func NewRoot() *Root {
 	return &Root{
 		Type:    "root",
-		Version: 1,
 		Expires: DefaultExpires("root"),
 		Keys:    make(map[string]*Key),
 		Roles:   make(map[string]*Role),
@@ -94,7 +93,6 @@ type Snapshot struct {
 func NewSnapshot() *Snapshot {
 	return &Snapshot{
 		Type:    "snapshot",
-		Version: 1,
 		Expires: DefaultExpires("snapshot"),
 		Meta:    make(Files),
 	}
@@ -116,7 +114,6 @@ type Targets struct {
 func NewTargets() *Targets {
 	return &Targets{
 		Type:    "targets",
-		Version: 1,
 		Expires: DefaultExpires("targets"),
 		Targets: make(Files),
 	}
@@ -132,7 +129,6 @@ type Timestamp struct {
 func NewTimestamp() *Timestamp {
 	return &Timestamp{
 		Type:    "timestamp",
-		Version: 1,
 		Expires: DefaultExpires("timestamp"),
 		Meta:    make(Files),
 	}

--- a/repo.go
+++ b/repo.go
@@ -178,6 +178,7 @@ func (r *Repo) GenKeyWithExpires(keyRole string, expires time.Time) error {
 
 	root.Keys[key.ID] = key.Serialize()
 	root.Expires = expires
+	root.Version++
 
 	return r.setMeta("root.json", root)
 }
@@ -297,6 +298,7 @@ func (r *Repo) AddTargetWithExpires(path string, custom map[string]interface{}, 
 		return err
 	}
 	t.Expires = expires
+	t.Version++
 	return r.setMeta("targets.json", t)
 }
 
@@ -318,6 +320,7 @@ func (r *Repo) RemoveTargetWithExpires(path string, expires time.Time) error {
 	}
 	delete(t.Targets, path)
 	t.Expires = expires
+	t.Version++
 	return r.setMeta("targets.json", t)
 }
 
@@ -350,6 +353,7 @@ func (r *Repo) SnapshotWithExpires(t CompressionType, expires time.Time) error {
 		}
 	}
 	snapshot.Expires = expires
+	snapshot.Version++
 	return r.setMeta("snapshot.json", snapshot)
 }
 
@@ -378,6 +382,7 @@ func (r *Repo) TimestampWithExpires(expires time.Time) error {
 		return err
 	}
 	timestamp.Expires = expires
+	timestamp.Version++
 	return r.setMeta("timestamp.json", timestamp)
 }
 

--- a/repo.go
+++ b/repo.go
@@ -443,21 +443,12 @@ func (r *Repo) Clean() error {
 }
 
 func (r *Repo) verifySignature(name string, db *keys.DB) error {
-	// need root.json to determine minimum version
-	if _, ok := r.meta["root.json"]; !ok {
-		return ErrMissingMetadata{"root.json"}
-	}
-	root, err := r.root()
-	if err != nil {
-		return err
-	}
-
 	s, err := r.signedMeta(name)
 	if err != nil {
 		return err
 	}
 	role := strings.TrimSuffix(name, ".json")
-	if err := signed.Verify(s, role, root.Version, db); err != nil {
+	if err := signed.Verify(s, role, 0, db); err != nil {
 		return ErrInsufficientSignatures{name, err}
 	}
 	return nil


### PR DESCRIPTION
See [commit message](https://github.com/flynn/go-tuf/commit/a38f45cc7924700ce732ebefbaf86db0b9d20ecf) for explanation of removing the version check in `verifySignature`, and I have opened #37 to track fixing version checking when committing changes.