### PR TITLE
encrypted: Fix go vet complaint about json tagged field

### DIFF
--- a/encrypted/encrypted.go
+++ b/encrypted/encrypted.go
@@ -100,7 +100,7 @@ type secretBoxCipher struct {
 	Name  string `json:"name"`
 	Nonce []byte `json:"nonce"`
 
-	encrypted bool `json:"-"`
+	encrypted bool
 }
 
 func (s *secretBoxCipher) Encrypt(plaintext, key []byte) []byte {


### PR DESCRIPTION
    encrypted.go:103: struct field encrypted has json tag but is not exported