### PR TITLE
data: Change FileMeta.Custom from map[string]interface{} to json.RawMessage

### DIFF
--- a/data/types.go
+++ b/data/types.go
@@ -99,9 +99,9 @@ func NewSnapshot() *Snapshot {
 }
 
 type FileMeta struct {
-	Length int64                  `json:"length"`
-	Hashes map[string]HexBytes    `json:"hashes"`
-	Custom map[string]interface{} `json:"custom,omitempty"`
+	Length int64               `json:"length"`
+	Hashes map[string]HexBytes `json:"hashes"`
+	Custom json.RawMessage     `json:"custom,omitempty"`
 }
 
 func (f FileMeta) HashAlgorithms() []string {


### PR DESCRIPTION
This allows consumers of the type to decode into any type instead of being stuck with a `map[string]interface{}`.