### PR TITLE
client: Handle updating root with keys that do not match the local meta

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -134,11 +134,11 @@ func (s *ClientSuite) genKeyExpired(c *C, role string) string {
 // the need to sleep in the tests).
 func (s *ClientSuite) withMetaExpired(f func()) {
 	e := signed.IsExpired
+	defer func() { signed.IsExpired = e }()
 	signed.IsExpired = func(t time.Time) bool {
 		return t.Unix() == s.expiredTime.Round(time.Second).Unix()
 	}
 	f()
-	signed.IsExpired = e
 }
 
 func (s *ClientSuite) syncLocal(c *C) {


### PR DESCRIPTION
Closes #39

Version downgrade attack during this scenario is not tested, as it is very unlikely (it would require intentionally signing a metadata file with the wrong version, which makes no sense). The version decode step was verified manually, as it would be very tricky to test (if you have a simple way of testing, suggestions welcome).