### PR TITLE
repo: Ensure target paths are always normalized

### DIFF
--- a/repo.go
+++ b/repo.go
@@ -404,7 +404,7 @@ func (r *Repo) AddTargetsWithExpires(paths []string, custom map[string]interface
 		normalizedPaths[i] = util.NormalizeTarget(path)
 	}
 	if err := r.local.WalkStagedTargets(normalizedPaths, func(path string, target io.Reader) (err error) {
-		t.Targets[path], err = util.GenerateFileMeta(target, r.hashAlgorithms...)
+		t.Targets[util.NormalizeTarget(path)], err = util.GenerateFileMeta(target, r.hashAlgorithms...)
 		return err
 	}); err != nil {
 		return err

--- a/tuf/main.go
+++ b/tuf/main.go
@@ -49,10 +49,10 @@ See "tuf help <command>" for more information on a specific command
 	cmdArgs := args.All["<args>"].([]string)
 
 	if cmd == "help" {
-		if len(cmdArgs) == 0 { // `flynn help`
+		if len(cmdArgs) == 0 { // `tuf help`
 			fmt.Println(usage)
 			return
-		} else { // `flynn help <command>`
+		} else { // `tuf help <command>`
 			cmd = cmdArgs[0]
 			cmdArgs = []string{"--help"}
 		}


### PR DESCRIPTION
When adding all staged targets, `WalkStagedTargets` calls the `targetsFn` with a path relative to the staged targets dir, so we need to normalize the path.