### PR TITLE
client: Add default targets path

### DIFF
--- a/client/remote_store.go
+++ b/client/remote_store.go
@@ -21,7 +21,10 @@ func HTTPRemoteStore(baseURL string, opts *HTTPRemoteOptions) (RemoteStore, erro
 		return nil, ErrInvalidURL{baseURL}
 	}
 	if opts == nil {
-		opts = &HTTPRemoteOptions{TargetsPath: "targets"}
+		opts = &HTTPRemoteOptions{}
+	}
+	if opts.TargetsPath == "" {
+		opts.TargetsPath = "targets"
 	}
 	return &httpRemoteStore{baseURL, opts}, nil
 }


### PR DESCRIPTION
There is no situation where an empty targets path makes sense, so it should default to `"targets"`.