### PR TITLE
repo: Prevent cleaning a new repository

### DIFF
--- a/cmd/tuf/clean.go
+++ b/cmd/tuf/clean.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"fmt"
+	"os"
+
 	"github.com/flynn/go-tuf"
 	"github.com/flynn/go-tuf/Godeps/_workspace/src/github.com/flynn/go-docopt"
 )
@@ -14,5 +17,10 @@ Remove all staged manifests.
 }
 
 func cmdClean(args *docopt.Args, repo *tuf.Repo) error {
-	return repo.Clean()
+	err := repo.Clean()
+	if err == tuf.ErrNewRepository {
+		fmt.Fprintln(os.Stderr, "tuf: refusing to clean new repository")
+		return nil
+	}
+	return err
 }

--- a/errors.go
+++ b/errors.go
@@ -6,7 +6,10 @@ import (
 	"time"
 )
 
-var ErrInitNotAllowed = errors.New("tuf: repository already initialized")
+var (
+	ErrInitNotAllowed = errors.New("tuf: repository already initialized")
+	ErrNewRepository  = errors.New("tuf: repository not yet committed")
+)
 
 type ErrMissingMetadata struct {
 	Name string

--- a/local_store.go
+++ b/local_store.go
@@ -400,6 +400,12 @@ func (f *fileSystemStore) keysPath(role string) string {
 }
 
 func (f *fileSystemStore) Clean() error {
+	_, err := os.Stat(filepath.Join(f.repoDir(), "root.json"))
+	if os.IsNotExist(err) {
+		return ErrNewRepository
+	} else if err != nil {
+		return err
+	}
 	if err := os.RemoveAll(f.stagedDir()); err != nil {
 		return err
 	}

--- a/repo_test.go
+++ b/repo_test.go
@@ -491,6 +491,9 @@ func (RepoSuite) TestCommitFileSystem(c *C) {
 	// don't use consistent snapshots to make the checks simpler
 	c.Assert(r.Init(false), IsNil)
 
+	// cleaning with nothing staged or committed should fail
+	c.Assert(r.Clean(), Equals, ErrNewRepository)
+
 	// generating keys should stage root.json and create repo dirs
 	genKey(c, r, "root")
 	genKey(c, r, "targets")
@@ -499,6 +502,9 @@ func (RepoSuite) TestCommitFileSystem(c *C) {
 	tmp.assertExists("staged/root.json")
 	tmp.assertEmpty("repository")
 	tmp.assertEmpty("staged/targets")
+
+	// cleaning with nothing committed should fail
+	c.Assert(r.Clean(), Equals, ErrNewRepository)
 
 	// adding a non-existent file fails
 	c.Assert(r.AddTarget("foo.txt", nil), Equals, ErrFileNotFound{tmp.stagedTargetPath("foo.txt")})


### PR DESCRIPTION
After creating keys in a new repository, `repo.Clean()` would remove the staged `root.json`, rendering the keys unusable.

Given `Clean` is only useful to reset the state to what is committed, it only makes sense to call it when something has been committed already, so this change prevents cleaning a new repository.

Fixes #78.