### PR TITLE
Don't reset custom metadata when not specified

### DIFF
--- a/repo.go
+++ b/repo.go
@@ -408,10 +408,17 @@ func (r *Repo) AddTargetsWithExpires(paths []string, custom json.RawMessage, exp
 		if err != nil {
 			return err
 		}
+		path = util.NormalizeTarget(path)
+
+		// if we have custom metadata, set it, otherwise maintain
+		// existing metadata if present
 		if len(custom) > 0 {
 			meta.Custom = &custom
+		} else if t, ok := t.Targets[path]; ok {
+			meta.Custom = t.Custom
 		}
-		t.Targets[util.NormalizeTarget(path)] = meta
+
+		t.Targets[path] = meta
 		return nil
 	}); err != nil {
 		return err


### PR DESCRIPTION
If I do the following:

```
tuf add --custom '{"foo":"bar"}' foo.txt
tuf add bar.txt
tuf add
```

I expect foo.txt to keep the metadata I give it, but that doesn't currently happen as `tuf add` will set metadata of all staged files to nil.

I have updated the logic to maintain custom metadata if the user hasn't specified any.