### PR TITLE
client: Always initialize keys DB from local storage

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -267,22 +267,21 @@ func (c *Client) getLocalMeta() error {
 		if err := json.Unmarshal(s.Signed, root); err != nil {
 			return err
 		}
-		db := keys.NewDB()
+		c.db = keys.NewDB()
 		for id, k := range root.Keys {
-			if err := db.AddKey(id, k); err != nil {
+			if err := c.db.AddKey(id, k); err != nil {
 				return err
 			}
 		}
 		for name, role := range root.Roles {
-			if err := db.AddRole(name, role); err != nil {
+			if err := c.db.AddRole(name, role); err != nil {
 				return err
 			}
 		}
-		if err := signed.Verify(s, "root", 0, db); err != nil {
+		if err := signed.Verify(s, "root", 0, c.db); err != nil {
 			return err
 		}
 		c.consistentSnapshot = root.ConsistentSnapshot
-		c.db = db
 	} else {
 		return ErrNoRootKeys
 	}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -531,6 +531,8 @@ func (s *ClientSuite) TestUpdateLocalRootExpired(c *C) {
 		if _, ok := err.(signed.ErrExpired); !ok {
 			c.Fatalf("expected err to have type signed.ErrExpired, got %T", err)
 		}
+
+		client := NewClient(s.local, s.remote)
 		_, err = client.Update()
 		c.Assert(err, IsNil)
 	})


### PR DESCRIPTION
If the local root is expired, an update will download the latest root from remote storage, and we need to be able to verify that new root with the local keys.

We should probably add a test to stop this regressing, but PRing without a test for feedback.

/cc @titanous 