### PR TITLE
Refactor key handling

### DIFF
--- a/client/interop_test.go
+++ b/client/interop_test.go
@@ -12,10 +12,10 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/agl/ed25519"
 	"github.com/flynn/go-tuf"
 	"github.com/flynn/go-tuf/data"
 	"github.com/flynn/go-tuf/util"
+	"golang.org/x/crypto/ed25519"
 	. "gopkg.in/check.v1"
 )
 

--- a/data/types.go
+++ b/data/types.go
@@ -4,12 +4,16 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"sync"
 	"time"
 
-	"github.com/tent/canonical-json-go"
+	cjson "github.com/tent/canonical-json-go"
 )
 
-const KeyIDLength = sha256.Size * 2
+const (
+	KeyIDLength    = sha256.Size * 2
+	KeyTypeEd25519 = "ed25519"
+)
 
 type Signed struct {
 	Signed     json.RawMessage `json:"signed"`
@@ -25,21 +29,22 @@ type Signature struct {
 type Key struct {
 	Type  string   `json:"keytype"`
 	Value KeyValue `json:"keyval"`
+
+	id     string
+	idOnce sync.Once
 }
 
 func (k *Key) ID() string {
-	// create a copy so the private key is not included
-	data, _ := cjson.Marshal(&Key{
-		Type:  k.Type,
-		Value: KeyValue{Public: k.Value.Public},
+	k.idOnce.Do(func() {
+		data, _ := cjson.Marshal(k)
+		digest := sha256.Sum256(data)
+		k.id = hex.EncodeToString(digest[:])
 	})
-	digest := sha256.Sum256(data)
-	return hex.EncodeToString(digest[:])
+	return k.id
 }
 
 type KeyValue struct {
-	Public  HexBytes `json:"public"`
-	Private HexBytes `json:"private,omitempty"`
+	Public HexBytes `json:"public"`
 }
 
 func DefaultExpires(role string) time.Time {

--- a/keys/db.go
+++ b/keys/db.go
@@ -4,8 +4,8 @@ import (
 	"crypto/rand"
 	"errors"
 
-	"github.com/agl/ed25519"
 	"github.com/flynn/go-tuf/data"
+	"golang.org/x/crypto/ed25519"
 )
 
 var (

--- a/repo_test.go
+++ b/repo_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/flynn/go-tuf/data"
 	"github.com/flynn/go-tuf/encrypted"
-	"github.com/flynn/go-tuf/keys"
 	"github.com/flynn/go-tuf/signed"
 	"github.com/flynn/go-tuf/util"
 	"golang.org/x/crypto/ed25519"
@@ -158,7 +157,6 @@ func (RepoSuite) TestGenKey(c *C) {
 	}
 	c.Assert(k.ID(), Equals, keyID)
 	c.Assert(k.Value.Public, HasLen, ed25519.PublicKeySize)
-	c.Assert(k.Value.Private, IsNil)
 
 	// check root key + role are in db
 	db, err := r.db()
@@ -170,7 +168,7 @@ func (RepoSuite) TestGenKey(c *C) {
 	c.Assert(role.KeyIDs, DeepEquals, map[string]struct{}{keyID: {}})
 
 	// check the key was saved correctly
-	localKeys, err := local.GetKeys("root")
+	localKeys, err := local.GetSigningKeys("root")
 	c.Assert(err, IsNil)
 	c.Assert(localKeys, HasLen, 1)
 	c.Assert(localKeys[0].ID(), Equals, keyID)
@@ -181,7 +179,6 @@ func (RepoSuite) TestGenKey(c *C) {
 	c.Assert(rootKeys, HasLen, 1)
 	c.Assert(rootKeys[0].ID(), Equals, rootKey.ID)
 	c.Assert(rootKeys[0].Value.Public, DeepEquals, rootKey.Serialize().Value.Public)
-	c.Assert(rootKeys[0].Value.Private, IsNil)
 
 	// generate two targets keys
 	genKey(c, r, "targets")
@@ -220,7 +217,7 @@ func (RepoSuite) TestGenKey(c *C) {
 	c.Assert(rootKeys[0].ID(), Equals, rootKey.ID)
 
 	// check the keys were saved correctly
-	localKeys, err = local.GetKeys("targets")
+	localKeys, err = local.GetSigningKeys("targets")
 	c.Assert(err, IsNil)
 	c.Assert(localKeys, HasLen, 2)
 	for _, key := range localKeys {
@@ -324,22 +321,22 @@ func (RepoSuite) TestSign(c *C) {
 	}
 
 	// signing with an available key generates a signature
-	key, err := keys.NewKey()
+	key, err := signed.GenerateEd25519Key()
 	c.Assert(err, IsNil)
-	c.Assert(local.SaveKey("root", key.SerializePrivate()), IsNil)
+	c.Assert(local.SavePrivateKey("root", key), IsNil)
 	c.Assert(r.Sign("root.json"), IsNil)
-	checkSigIDs(key.ID)
+	checkSigIDs(key.PublicData().ID())
 
 	// signing again does not generate a duplicate signature
 	c.Assert(r.Sign("root.json"), IsNil)
-	checkSigIDs(key.ID)
+	checkSigIDs(key.PublicData().ID())
 
 	// signing with a new available key generates another signature
-	newKey, err := keys.NewKey()
+	newKey, err := signed.GenerateEd25519Key()
 	c.Assert(err, IsNil)
-	c.Assert(local.SaveKey("root", newKey.SerializePrivate()), IsNil)
+	c.Assert(local.SavePrivateKey("root", newKey), IsNil)
 	c.Assert(r.Sign("root.json"), IsNil)
-	checkSigIDs(key.ID, newKey.ID)
+	checkSigIDs(key.PublicData().ID(), newKey.PublicData().ID())
 }
 
 func (RepoSuite) TestCommit(c *C) {
@@ -764,22 +761,13 @@ func (RepoSuite) TestKeyPersistence(c *C) {
 	passphrase := []byte("s3cr3t")
 	store := FileSystemStore(tmp.path, testPassphraseFunc(passphrase))
 
-	assertEqual := func(actual []*data.Key, expected []*keys.Key) {
-		c.Assert(actual, HasLen, len(expected))
-		for i, key := range expected {
-			c.Assert(actual[i].ID(), Equals, key.ID)
-			c.Assert(actual[i].Value.Public, DeepEquals, data.HexBytes(key.Public[:]))
-			c.Assert(actual[i].Value.Private, DeepEquals, data.HexBytes(key.Private[:]))
-		}
-	}
-
-	assertKeys := func(role string, enc bool, expected []*keys.Key) {
+	assertKeys := func(role string, enc bool, expected []*signed.PrivateKey) {
 		keysJSON := tmp.readFile("keys/" + role + ".json")
 		pk := &persistedKeys{}
 		c.Assert(json.Unmarshal(keysJSON, pk), IsNil)
 
 		// check the persisted keys are correct
-		var actual []*data.Key
+		var actual []*signed.PrivateKey
 		if enc {
 			c.Assert(pk.Encrypted, Equals, true)
 			decrypted, err := encrypted.Decrypt(pk.Data, passphrase)
@@ -789,37 +777,43 @@ func (RepoSuite) TestKeyPersistence(c *C) {
 			c.Assert(pk.Encrypted, Equals, false)
 			c.Assert(json.Unmarshal(pk.Data, &actual), IsNil)
 		}
-		assertEqual(actual, expected)
+		c.Assert(actual, HasLen, len(expected))
+		for i, key := range expected {
+			c.Assert(expected[i], DeepEquals, key)
+		}
 
 		// check GetKeys is correct
-		actual, err := store.GetKeys(role)
+		signers, err := store.GetSigningKeys(role)
 		c.Assert(err, IsNil)
-		assertEqual(actual, expected)
+		c.Assert(signers, HasLen, len(expected))
+		for i, s := range signers {
+			c.Assert(s.ID(), Equals, expected[i].PublicData().ID())
+		}
 	}
 
 	// save a key and check it gets encrypted
-	key, err := keys.NewKey()
+	key, err := signed.GenerateEd25519Key()
 	c.Assert(err, IsNil)
-	c.Assert(store.SaveKey("root", key.SerializePrivate()), IsNil)
-	assertKeys("root", true, []*keys.Key{key})
+	c.Assert(store.SavePrivateKey("root", key), IsNil)
+	assertKeys("root", true, []*signed.PrivateKey{key})
 
 	// save another key and check it gets added to the existing keys
-	newKey, err := keys.NewKey()
+	newKey, err := signed.GenerateEd25519Key()
 	c.Assert(err, IsNil)
-	c.Assert(store.SaveKey("root", newKey.SerializePrivate()), IsNil)
-	assertKeys("root", true, []*keys.Key{key, newKey})
+	c.Assert(store.SavePrivateKey("root", newKey), IsNil)
+	assertKeys("root", true, []*signed.PrivateKey{key, newKey})
 
 	// check saving a key to an encrypted file without a passphrase fails
 	insecureStore := FileSystemStore(tmp.path, nil)
-	key, err = keys.NewKey()
+	key, err = signed.GenerateEd25519Key()
 	c.Assert(err, IsNil)
-	c.Assert(insecureStore.SaveKey("root", key.SerializePrivate()), Equals, ErrPassphraseRequired{"root"})
+	c.Assert(insecureStore.SavePrivateKey("root", key), Equals, ErrPassphraseRequired{"root"})
 
 	// save a key to an insecure store and check it is not encrypted
-	key, err = keys.NewKey()
+	key, err = signed.GenerateEd25519Key()
 	c.Assert(err, IsNil)
-	c.Assert(insecureStore.SaveKey("targets", key.SerializePrivate()), IsNil)
-	assertKeys("targets", false, []*keys.Key{key})
+	c.Assert(insecureStore.SavePrivateKey("targets", key), IsNil)
+	assertKeys("targets", false, []*signed.PrivateKey{key})
 }
 
 func (RepoSuite) TestManageMultipleTargets(c *C) {

--- a/repo_test.go
+++ b/repo_test.go
@@ -10,12 +10,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/agl/ed25519"
 	"github.com/flynn/go-tuf/data"
 	"github.com/flynn/go-tuf/encrypted"
 	"github.com/flynn/go-tuf/keys"
 	"github.com/flynn/go-tuf/signed"
 	"github.com/flynn/go-tuf/util"
+	"golang.org/x/crypto/ed25519"
 	. "gopkg.in/check.v1"
 )
 

--- a/signed/keys.go
+++ b/signed/keys.go
@@ -1,0 +1,69 @@
+package signed
+
+import (
+	"crypto/rand"
+	"sync"
+
+	"github.com/flynn/go-tuf/data"
+	"golang.org/x/crypto/ed25519"
+)
+
+type PrivateKey struct {
+	Type  string          `json:"keytype"`
+	Value PrivateKeyValue `json:"keyval"`
+}
+
+type PrivateKeyValue struct {
+	Public  data.HexBytes `json:"public"`
+	Private data.HexBytes `json:"private"`
+}
+
+func (k *PrivateKey) PublicData() *data.Key {
+	return &data.Key{
+		Type:  k.Type,
+		Value: data.KeyValue{Public: k.Value.Public},
+	}
+}
+
+func (k *PrivateKey) Signer() Signer {
+	return &ed25519Signer{PrivateKey: ed25519.PrivateKey(k.Value.Private)}
+}
+
+func GenerateEd25519Key() (*PrivateKey, error) {
+	public, private, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return nil, err
+	}
+	return &PrivateKey{
+		Type: data.KeyTypeEd25519,
+		Value: PrivateKeyValue{
+			Public:  data.HexBytes(public),
+			Private: data.HexBytes(private),
+		},
+	}, nil
+}
+
+type ed25519Signer struct {
+	ed25519.PrivateKey
+
+	id     string
+	idOnce sync.Once
+}
+
+var _ Signer = &ed25519Signer{}
+
+func (s *ed25519Signer) ID() string {
+	s.idOnce.Do(func() { s.id = s.publicData().ID() })
+	return s.id
+}
+
+func (s *ed25519Signer) publicData() *data.Key {
+	return &data.Key{
+		Type:  data.KeyTypeEd25519,
+		Value: data.KeyValue{Public: []byte(s.PrivateKey.Public().(ed25519.PublicKey))},
+	}
+}
+
+func (s *ed25519Signer) Type() string {
+	return data.KeyTypeEd25519
+}

--- a/signed/sign.go
+++ b/signed/sign.go
@@ -1,12 +1,27 @@
 package signed
 
 import (
-	"github.com/agl/ed25519"
+	"crypto"
+	"crypto/rand"
+
 	"github.com/flynn/go-tuf/data"
 	"github.com/tent/canonical-json-go"
 )
 
-func Sign(s *data.Signed, k *data.Key) {
+type Signer interface {
+	// ID returns the TUF key id
+	ID() string
+
+	// Type returns the TUF key type
+	Type() string
+
+	// Signer is used to sign messages and provides access to the public key.
+	// The signer is expected to do its own hashing, so the full message will be
+	// provided as the message to Sign with a zero opts.HashFunc().
+	crypto.Signer
+}
+
+func Sign(s *data.Signed, k Signer) error {
 	id := k.ID()
 	signatures := make([]data.Signature, 0, len(s.Signatures)+1)
 	for _, sig := range s.Signatures {
@@ -15,24 +30,32 @@ func Sign(s *data.Signed, k *data.Key) {
 		}
 		signatures = append(signatures, sig)
 	}
-	priv := [ed25519.PrivateKeySize]byte{}
-	copy(priv[:], k.Value.Private)
-	sig := ed25519.Sign(&priv, s.Signed)
+
+	sig, err := k.Sign(rand.Reader, s.Signed, crypto.Hash(0))
+	if err != nil {
+		return err
+	}
+
 	s.Signatures = append(signatures, data.Signature{
 		KeyID:     id,
-		Method:    "ed25519",
-		Signature: sig[:],
+		Method:    k.Type(),
+		Signature: sig,
 	})
+
+	return nil
 }
 
-func Marshal(v interface{}, keys ...*data.Key) (*data.Signed, error) {
+func Marshal(v interface{}, keys ...Signer) (*data.Signed, error) {
 	b, err := cjson.Marshal(v)
 	if err != nil {
 		return nil, err
 	}
 	s := &data.Signed{Signed: b}
 	for _, k := range keys {
-		Sign(s, k)
+		if err := Sign(s, k); err != nil {
+			return nil, err
+		}
+
 	}
 	return s, nil
 }

--- a/signed/verifiers.go
+++ b/signed/verifiers.go
@@ -1,6 +1,7 @@
 package signed
 
 import (
+	"github.com/flynn/go-tuf/data"
 	"golang.org/x/crypto/ed25519"
 )
 
@@ -13,9 +14,9 @@ type Verifier interface {
 	Verify(key, msg, sig []byte) error
 }
 
-// Verifiers is used to map algorithm names to Verifier instances.
+// Verifiers is used to map key types to Verifier instances.
 var Verifiers = map[string]Verifier{
-	"ed25519": Ed25519Verifier{},
+	data.KeyTypeEd25519: Ed25519Verifier{},
 }
 
 // RegisterVerifier provides a convenience function for init() functions

--- a/signed/verifiers.go
+++ b/signed/verifiers.go
@@ -1,7 +1,7 @@
 package signed
 
 import (
-	"github.com/agl/ed25519"
+	"golang.org/x/crypto/ed25519"
 )
 
 // Verifier describes the verification interface. Implement this interface
@@ -10,7 +10,7 @@ type Verifier interface {
 	// Verify takes a key, message and signature, all as byte slices,
 	// and determines whether the signature is valid for the given
 	// key and message.
-	Verify(key []byte, msg []byte, sig []byte) error
+	Verify(key, msg, sig []byte) error
 }
 
 // Verifiers is used to map algorithm names to Verifier instances.
@@ -28,16 +28,7 @@ func RegisterVerifier(name string, v Verifier) {
 type Ed25519Verifier struct{}
 
 func (v Ed25519Verifier) Verify(key []byte, msg []byte, sig []byte) error {
-	var sigBytes [ed25519.SignatureSize]byte
-	if len(sig) != len(sigBytes) {
-		return ErrInvalid
-	}
-	copy(sigBytes[:], sig)
-
-	var keyBytes [ed25519.PublicKeySize]byte
-	copy(keyBytes[:], key)
-
-	if !ed25519.Verify(&keyBytes, msg, &sigBytes) {
+	if !ed25519.Verify(key, msg, sig) {
 		return ErrInvalid
 	}
 	return nil

--- a/signed/verifiers.go
+++ b/signed/verifiers.go
@@ -1,11 +1,6 @@
 package signed
 
 import (
-	"crypto"
-	"crypto/rsa"
-	"crypto/sha256"
-	"crypto/x509"
-
 	"github.com/agl/ed25519"
 )
 
@@ -21,7 +16,6 @@ type Verifier interface {
 // Verifiers is used to map algorithm names to Verifier instances.
 var Verifiers = map[string]Verifier{
 	"ed25519": Ed25519Verifier{},
-	//"rsa":     RSAVerifier{},
 }
 
 // RegisterVerifier provides a convenience function for init() functions
@@ -44,28 +38,6 @@ func (v Ed25519Verifier) Verify(key []byte, msg []byte, sig []byte) error {
 	copy(keyBytes[:], key)
 
 	if !ed25519.Verify(&keyBytes, msg, &sigBytes) {
-		return ErrInvalid
-	}
-	return nil
-}
-
-// RSAVerifier is an implementation of a Verifier that verifies RSA signatures.
-// N.B. Currently not covered by unit tests, use at your own risk.
-type RSAVerifier struct{}
-
-func (v RSAVerifier) Verify(key []byte, msg []byte, sig []byte) error {
-	digest := sha256.Sum256(msg)
-	pub, err := x509.ParsePKIXPublicKey(key)
-	if err != nil {
-		return ErrInvalid
-	}
-
-	rsaPub, ok := pub.(*rsa.PublicKey)
-	if !ok {
-		return ErrInvalid
-	}
-
-	if err = rsa.VerifyPKCS1v15(rsaPub, crypto.SHA256, digest[:], sig); err != nil {
 		return ErrInvalid
 	}
 	return nil

--- a/signed/verify.go
+++ b/signed/verify.go
@@ -6,10 +6,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/agl/ed25519"
 	"github.com/flynn/go-tuf/data"
 	"github.com/flynn/go-tuf/keys"
 	"github.com/tent/canonical-json-go"
+	"golang.org/x/crypto/ed25519"
 )
 
 var (

--- a/signed/verify_test.go
+++ b/signed/verify_test.go
@@ -76,10 +76,10 @@ func (VerifySuite) Test(c *C) {
 		{
 			name: "more than enough signatures",
 			mut: func(t *test) {
-				k, _ := keys.NewKey()
-				Sign(t.s, k.SerializePrivate())
-				t.keys = append(t.keys, k.Serialize())
-				t.roles["root"].KeyIDs = append(t.roles["root"].KeyIDs, k.ID)
+				k, _ := GenerateEd25519Key()
+				Sign(t.s, k.Signer())
+				t.keys = append(t.keys, k.PublicData())
+				t.roles["root"].KeyIDs = append(t.roles["root"].KeyIDs, k.PublicData().ID())
 			},
 		},
 		{
@@ -93,15 +93,15 @@ func (VerifySuite) Test(c *C) {
 		{
 			name: "unknown key",
 			mut: func(t *test) {
-				k, _ := keys.NewKey()
-				Sign(t.s, k.Serialize())
+				k, _ := GenerateEd25519Key()
+				Sign(t.s, k.Signer())
 			},
 		},
 		{
 			name: "unknown key below threshold",
 			mut: func(t *test) {
-				k, _ := keys.NewKey()
-				Sign(t.s, k.Serialize())
+				k, _ := GenerateEd25519Key()
+				Sign(t.s, k.Signer())
 				t.roles["root"].Threshold = 2
 			},
 			err: ErrRoleThreshold,
@@ -109,17 +109,17 @@ func (VerifySuite) Test(c *C) {
 		{
 			name: "unknown keys in db",
 			mut: func(t *test) {
-				k, _ := keys.NewKey()
-				Sign(t.s, k.Serialize())
-				t.keys = append(t.keys, k.Serialize())
+				k, _ := GenerateEd25519Key()
+				Sign(t.s, k.Signer())
+				t.keys = append(t.keys, k.PublicData())
 			},
 		},
 		{
 			name: "unknown keys in db below threshold",
 			mut: func(t *test) {
-				k, _ := keys.NewKey()
-				Sign(t.s, k.Serialize())
-				t.keys = append(t.keys, k.Serialize())
+				k, _ := GenerateEd25519Key()
+				Sign(t.s, k.Signer())
+				t.keys = append(t.keys, k.PublicData())
 				t.roles["root"].Threshold = 2
 			},
 			err: ErrRoleThreshold,
@@ -155,9 +155,9 @@ func (VerifySuite) Test(c *C) {
 			t.typ = t.role
 		}
 		if t.keys == nil && t.s == nil {
-			k, _ := keys.NewKey()
-			t.s, _ = Marshal(&signedMeta{Type: t.typ, Version: t.ver, Expires: *t.exp}, k.SerializePrivate())
-			t.keys = []*data.Key{k.Serialize()}
+			k, _ := GenerateEd25519Key()
+			t.s, _ = Marshal(&signedMeta{Type: t.typ, Version: t.ver, Expires: *t.exp}, k.Signer())
+			t.keys = []*data.Key{k.PublicData()}
 		}
 		if t.roles == nil {
 			t.roles = map[string]*data.Role{

--- a/signed/verify_test.go
+++ b/signed/verify_test.go
@@ -4,9 +4,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/agl/ed25519"
 	"github.com/flynn/go-tuf/data"
 	"github.com/flynn/go-tuf/keys"
+	"golang.org/x/crypto/ed25519"
 
 	. "gopkg.in/check.v1"
 )


### PR DESCRIPTION
This is the first step towards supporting ECDSA keys and signing via PKCS11.

- Remove unused RSA signature verifier.
- Use `golang.org/x/crypto/ed25519` package instead of `github.com/agl/ed25519`.
- Don't mix private and public key structs, use a separate struct
  for private keys.
- Only store public keys in database used for signature
  verification.
- Use `crypto.Signer` interface instead of providing private keys
  directly when signing.
- Don't make as many assumptions about using Ed25519 keys
  everywhere.
- Ignore unknown key types when populating the public key database.

I've tested that keys generated with the previous implementation can be decoded and used by this refactored code (there is no change in the serialized data structures).