### PR TITLE
ECDSA verification support

### DIFF
--- a/data/types.go
+++ b/data/types.go
@@ -11,8 +11,9 @@ import (
 )
 
 const (
-	KeyIDLength    = sha256.Size * 2
-	KeyTypeEd25519 = "ed25519"
+	KeyIDLength            = sha256.Size * 2
+	KeyTypeEd25519         = "ed25519"
+	KeyTypeECDSA_SHA2_P256 = "ecdsa-sha2-nistp256"
 )
 
 type Signed struct {


### PR DESCRIPTION
- verify: Don't assume signature method, use key type

    It is unsafe to use the signature method field, as it could result in a key confusion attack. Use the key type instead.
    Also, don't assume that we're only working with Ed25519.
-  	verify: Add support for `ecdsa-sha2-p256` signatures