### PR TITLE
encrypted: fix flake in EncryptedSuite.TestTamperedRoundtrip

### DIFF
--- a/encrypted/encrypted_test.go
+++ b/encrypted/encrypted_test.go
@@ -44,8 +44,7 @@ func (EncryptedSuite) TestTamperedRoundtrip(c *C) {
 	err = json.Unmarshal(enc, data)
 	c.Assert(err, IsNil)
 
-	data.Ciphertext[0] = 0
-	data.Ciphertext[1] = 0
+	data.Ciphertext[0] = ^data.Ciphertext[0]
 
 	enc, _ = json.Marshal(data)
 


### PR DESCRIPTION
If we get really unlucky the encrypted bytes already start with 0x0000
so the tampering fails.

Signed-off-by: Dan Johnson <computerdruid@google.com>